### PR TITLE
Handle missing field in answer evaluation

### DIFF
--- a/frontend/app/pages/study.vue
+++ b/frontend/app/pages/study.vue
@@ -143,11 +143,8 @@ async function evaluateAnswer() {
     try {
       const responseData = await $authFetch<{
         feedback: string;
-      }>(`/tasks/evaluate_answer/${currentTask.value?.id}`, {
+      }>(`/tasks/evaluate_answer/${currentTask.value?.id}?student_answer=${encodeURIComponent(currentAnswer.value)}`, {
         method: "POST",
-        body: {
-          student_answer: currentAnswer.value,
-        },
       });
       feedback.value = responseData.feedback || null;
     } catch (e: any) {


### PR DESCRIPTION
Correctly sends `student_answer` as a URL query parameter to resolve a 422 "Field required" error.

The backend API for `/tasks/evaluate_answer` expects `student_answer` as a query parameter, but it was previously being sent in the request body, leading to a 422 Unprocessable Entity error. This change aligns the frontend request with the backend's expectation.

---
<a href="https://cursor.com/background-agent?bcId=bc-a660c4c0-cb33-4cc6-9f46-3418a58c77d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a660c4c0-cb33-4cc6-9f46-3418a58c77d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

